### PR TITLE
Remove enterprise apt repo after proxmox install

### DIFF
--- a/roles/proxmox-host/defaults/main.yaml
+++ b/roles/proxmox-host/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+proxmox_enterprise: False

--- a/roles/proxmox-host/tasks/proxmox.yaml
+++ b/roles/proxmox-host/tasks/proxmox.yaml
@@ -35,3 +35,9 @@
   package:
     name: open-iscsi
     state: latest
+
+- name: Remove enterprise proxmox repo from apt
+  apt_repository:
+    repo: deb https://enterprise.proxmox.com/debian/pve stretch pve-enterprise
+    state: absent
+  when: ansible_distribution == 'Debian' and not proxmox_enterprise


### PR DESCRIPTION
Without a subscription this results in a broken apt-get update.